### PR TITLE
add prefix and suffix for multiple registry format

### DIFF
--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestCommandLoad(t *testing.T) {
-
-	t.Run("test-chart", func(t *testing.T) {
+	t.Run("gen-tarball", func(t *testing.T) {
 		filePath := "image-load.tgz"
 		output, err := executeCommand(rootCmd, "save ../testdata/test-chart4 -a custom/loadimages --output "+filePath)
 		assert.NoError(t, err)
@@ -22,15 +21,25 @@ Tarball created successfully: image-load.tgz`
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {
 			t.Errorf("File was not created: %s", filePath)
 		}
-
-		output, err = executeCommand(rootCmd, "load "+filePath+" -r ttl.sh")
+	})
+	t.Run("prefix-suffix", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "load image-load.tgz -r ttl.sh --prefix prefix --suffix suffix")
 		assert.NoError(t, err)
-		expectedLoadOutput := `Successfully pushed image ttl.sh/curl:8.9.1
-Successfully pushed image ttl.sh/busybox:1.36.1`
+		expectedLoadOutput := `Successfully pushed image ttl.sh/prefix/suffix/curl:8.9.1
+Successfully pushed image ttl.sh/prefix/suffix/busybox:1.36.1`
 		assert.Equal(t, expectedLoadOutput, output)
-
+	})
+	t.Run("repo", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "load image-load.tgz -r ocp.example.com --dry-run --repo openshift-image-registry/test ")
+		assert.NoError(t, err)
+		expectedLoadOutput := `[Dry-Run] Pushing image: ocp.example.com/openshift-image-registry/test/curl:8.9.1
+[Dry-Run] Pushing image: ocp.example.com/openshift-image-registry/test/busybox:1.36.1`
+		assert.Equal(t, expectedLoadOutput, output)
+	})
+	t.Run("cleanup-tarball", func(t *testing.T) {
+		filePath := "image-load.tgz"
 		// Clean up: remove the file after the test
-		err = os.Remove(filePath)
+		err := os.Remove(filePath)
 		if err != nil {
 			t.Fatalf("Failed to remove file: %v", err)
 		}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -38,19 +38,17 @@ Pushing image: registry.example.com/datarobot/test-image1:1.0.0
 			if err != nil {
 				return err
 			}
-
 			srcImage := iUri.String()
 			if image.Tag != "" {
 				iUri.Tag = image.Tag
 			}
 
 			iUri.RegistryHost = syncReg
-			if syncRefPrefix != "" {
-				if iUri.Organization == "" {
-					iUri.Organization = syncRefPrefix
-				} else {
-					iUri.Organization = strings.Join([]string{syncRefPrefix, iUri.Organization}, "/")
-				}
+			iUri.Organization = iUri.Join([]string{syncImagePrefix, iUri.Organization}, "/")
+			iUri.Project = iUri.Join([]string{iUri.Project, syncImageSuffix}, "/")
+			if syncImageRepo != "" {
+				iUri.Organization = syncImageRepo
+				iUri.Project = ""
 			}
 
 			dstImage := iUri.String()
@@ -98,16 +96,19 @@ Pushing image: registry.example.com/datarobot/test-image1:1.0.0
 	},
 }
 
-var syncReg, syncUsername, syncPassword, syncToken, syncRefPrefix, caCertPath, certPath, keyPath string
+var syncReg, syncUsername, syncPassword, syncToken, syncImagePrefix, syncImageSuffix, syncImageRepo, syncTransform, caCertPath, certPath, keyPath string
 var syncDryRun, skipTlsVerify bool
 
 func init() {
 	rootCmd.AddCommand(syncCmd)
+	syncCmd.Flags().StringVarP(&annotation, "annotation", "a", "datarobot.com/images", "annotation to lookup")
 	syncCmd.Flags().StringVarP(&syncUsername, "username", "u", "", "username to auth")
 	syncCmd.Flags().StringVarP(&syncPassword, "password", "p", "", "pass to auth")
 	syncCmd.Flags().StringVarP(&syncToken, "token", "t", "", "pass to auth")
 	syncCmd.Flags().StringVarP(&syncReg, "registry", "r", "", "registry to auth")
-	syncCmd.Flags().StringVarP(&syncRefPrefix, "prefix", "", "", "append prefix on repo name")
+	syncCmd.Flags().StringVarP(&syncImagePrefix, "prefix", "", "", "append prefix on repo name")
+	syncCmd.Flags().StringVarP(&syncImageRepo, "repo", "", "", "rewrite the target repository name")
+	syncCmd.Flags().StringVarP(&syncImageSuffix, "suffix", "", "", "append suffix on repo name")
 	syncCmd.Flags().BoolVarP(&syncDryRun, "dry-run", "", false, "Perform a dry run without making changes")
 	syncCmd.Flags().StringVarP(&caCertPath, "ca-cert", "c", "", "Path to the custom CA certificate")
 	syncCmd.Flags().StringVarP(&certPath, "cert", "C", "", "Path to the client certificate")

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -6,24 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandSync(t *testing.T) {
-	t.Run("test-chart4", func(t *testing.T) {
-		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r registry.example.com -u testuser -p testpass --dry-run")
-		assert.NoError(t, err)
-		expectedOutput := `[Dry-Run] Pulling image: docker.io/alpine/curl:8.9.1
-[Dry-Run] Pushing image: registry.example.com/alpine/curl:stable
-
-[Dry-Run] Pulling image: docker.io/busybox:1.36.1
-[Dry-Run] Pushing image: registry.example.com/busybox:simple
-
-[Dry-Run] Pulling image: docker.io/alpine/curl:8.10.0
-[Dry-Run] Pushing image: registry.example.com/alpine/curl:8.10.0`
-		assert.Equal(t, expectedOutput, output)
-	})
-}
 func TestCommandSyncLive(t *testing.T) {
 	t.Run("test-chart4 ttl.sh", func(t *testing.T) {
-		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r ttl.sh --dry-run=false")
+		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r ttl.sh --dry-run=false -a datarobot.com/images")
 		assert.NoError(t, err)
 		// Expected output to compare
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
@@ -67,4 +52,37 @@ Pushing image: ttl.sh/alpine/curl:8.10.0`
 	//		// Compare the actual output with the expected output
 	//		assert.Equal(t, expectedOutput, stdoutBuf.String())
 	//	})
+}
+
+func TestCommandSync(t *testing.T) {
+	t.Run("test-chart4", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r registry.example.com -u testuser -p testpass --dry-run")
+		assert.NoError(t, err)
+		expectedOutput := `[Dry-Run] Pulling image: docker.io/alpine/curl:8.9.1
+[Dry-Run] Pushing image: registry.example.com/alpine/curl:stable
+
+[Dry-Run] Pulling image: docker.io/busybox:1.36.1
+[Dry-Run] Pushing image: registry.example.com/busybox:simple
+
+[Dry-Run] Pulling image: docker.io/alpine/curl:8.10.0
+[Dry-Run] Pushing image: registry.example.com/alpine/curl:8.10.0`
+		assert.Equal(t, expectedOutput, output)
+	})
+
+	t.Run("test-chart4/prefix-suffix", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r registry.example.com --dry-run -a custom/images --prefix prefix --suffix suffix ")
+		assert.NoError(t, err)
+		expectedOutput := `[Dry-Run] Pulling image: docker.io/datarobotdev/test-image4:4.0.0
+[Dry-Run] Pushing image: registry.example.com/prefix/datarobotdev/suffix/test-image4:4.0.0`
+
+		assert.Equal(t, expectedOutput, output)
+	})
+	t.Run("test-chart4/repo", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../testdata/test-chart4 -r ocp.example.com --dry-run -a custom/images --repo openshift-image-registry/test ")
+		assert.NoError(t, err)
+		expectedOutput := `[Dry-Run] Pulling image: docker.io/datarobotdev/test-image4:4.0.0
+[Dry-Run] Pushing image: ocp.example.com/openshift-image-registry/test/test-image4:4.0.0`
+
+		assert.Equal(t, expectedOutput, output)
+	})
 }

--- a/docs/helm-datarobot_load.md
+++ b/docs/helm-datarobot_load.md
@@ -24,12 +24,15 @@ helm-datarobot load [flags]
 ```
   -c, --ca-cert string    Path to the custom CA certificate
   -C, --cert string       Path to the client certificate
+      --dry-run           Perform a dry run without making changes
   -h, --help              help for load
   -i, --insecure          Skip server certificate verification
   -K, --key string        Path to the client key
   -p, --password string   pass to auth
       --prefix string     append prefix on repo name
   -r, --registry string   registry to auth
+      --repo string       rewrite the target repository name
+      --suffix string     append suffix on repo name
   -t, --token string      pass to auth
   -u, --username string   username to auth
 ```

--- a/docs/helm-datarobot_sync.md
+++ b/docs/helm-datarobot_sync.md
@@ -24,17 +24,20 @@ helm-datarobot sync [flags]
 ### Options
 
 ```
-  -c, --ca-cert string    Path to the custom CA certificate
-  -C, --cert string       Path to the client certificate
-      --dry-run           Perform a dry run without making changes
-  -h, --help              help for sync
-  -i, --insecure          Skip server certificate verification
-  -K, --key string        Path to the client key
-  -p, --password string   pass to auth
-      --prefix string     append prefix on repo name
-  -r, --registry string   registry to auth
-  -t, --token string      pass to auth
-  -u, --username string   username to auth
+  -a, --annotation string   annotation to lookup (default "datarobot.com/images")
+  -c, --ca-cert string      Path to the custom CA certificate
+  -C, --cert string         Path to the client certificate
+      --dry-run             Perform a dry run without making changes
+  -h, --help                help for sync
+  -i, --insecure            Skip server certificate verification
+  -K, --key string          Path to the client key
+  -p, --password string     pass to auth
+      --prefix string       append prefix on repo name
+  -r, --registry string     registry to auth
+      --repo string         rewrite the target repository name
+      --suffix string       append suffix on repo name
+  -t, --token string        pass to auth
+  -u, --username string     username to auth
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
### Description of the change

adding `prefix` `suffix` and `repo` flag on `load` and `sync`.
implement `dry-run` on `load`

### Benefits

With those flags we can load to any registry with any repository format such as Google Artifacts and OCR

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

