### PR TITLE
bug: skip duplicated image on save

### DIFF
--- a/cmd/save.go
+++ b/cmd/save.go
@@ -82,6 +82,11 @@ $ du -h images.tgz
 			}
 
 			tgzFileName := iUri.Join([]string{imageDir, iUri.ImageName}, "/") + ":" + iUri.Tag + ".tgz"
+			if _, err := os.Stat(tgzFileName); err == nil {
+				cmd.Printf(" archive %s already exists\n", tgzFileName)
+				continue
+			}
+
 			if saveDryRun {
 				cmd.Printf("[Dry-Run] adding image to tgz: %s\n", tgzFileName)
 			} else {

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -28,7 +28,7 @@ func TestCommandSave(t *testing.T) {
 	t.Run("duplicated", func(t *testing.T) {
 
 		filePath := "image-test.tgz"
-		output, err := executeCommand(rootCmd, "save ../testdata/test-chart5 a custom/images-duplicated --dry-run=false --output "+filePath)
+		output, err := executeCommand(rootCmd, "save ../testdata/test-chart5 -a custom/images-duplicated --dry-run=false --output "+filePath)
 		assert.NoError(t, err)
 
 		// Expected output to compare

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -25,6 +25,32 @@ func TestCommandSave(t *testing.T) {
 		assert.Equal(t, expectedOutput, output)
 	})
 
+	t.Run("duplicated", func(t *testing.T) {
+
+		filePath := "image-test.tgz"
+		output, err := executeCommand(rootCmd, "save ../testdata/test-chart5 a custom/images-duplicated --dry-run=false --output "+filePath)
+		assert.NoError(t, err)
+
+		// Expected output to compare
+		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
+Pulling image: docker.io/alpine/curl:8.9.1
+ archive alpine/curl:8.9.1.tgz already exist
+Tarball created successfully: images.tgz`
+
+		assert.Equal(t, expectedOutput, output)
+
+		// Check if the file exists
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			t.Errorf("File was not created: %s", filePath)
+		}
+
+		// Clean up: remove the file after the test
+		err = os.Remove(filePath)
+		if err != nil {
+			t.Fatalf("Failed to remove file: %v", err)
+		}
+	})
+
 	t.Run("test-chart4", func(t *testing.T) {
 
 		filePath := "image-test.tgz"

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -33,7 +33,7 @@ func TestCommandSave(t *testing.T) {
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
 Pulling image: docker.io/alpine/curl:8.9.1
  archive alpine/curl:8.9.1.tgz already exists
-Tarball created successfully: images-test.tgz`
+Tarball created successfully: image-test.tgz`
 
 		assert.Equal(t, expectedOutput, output)
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -30,21 +30,15 @@ func TestCommandSave(t *testing.T) {
 		filePath := "image-test.tgz"
 		output, err := executeCommand(rootCmd, "save ../testdata/test-chart5 -a custom/images-duplicated --dry-run=false --output "+filePath)
 		assert.NoError(t, err)
-
-		// Expected output to compare
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
 Pulling image: docker.io/alpine/curl:8.9.1
- archive alpine/curl:8.9.1.tgz already exist
+ archive alpine/curl:8.9.1.tgz already exists
 Tarball created successfully: images-test.tgz`
 
 		assert.Equal(t, expectedOutput, output)
-
-		// Check if the file exists
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {
 			t.Errorf("File was not created: %s", filePath)
 		}
-
-		// Clean up: remove the file after the test
 		err = os.Remove(filePath)
 		if err != nil {
 			t.Fatalf("Failed to remove file: %v", err)

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -33,6 +33,7 @@ func TestCommandSave(t *testing.T) {
 
 		// Expected output to compare
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
+Pulling image: docker.io/alpine/curl:8.9.1
  archive alpine/curl:8.9.1.tgz already exist
 Tarball created successfully: images-test.tgz`
 

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -33,7 +33,6 @@ func TestCommandSave(t *testing.T) {
 
 		// Expected output to compare
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
-Pulling image: docker.io/alpine/curl:8.9.1
  archive alpine/curl:8.9.1.tgz already exist
 Tarball created successfully: images.tgz`
 

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -34,7 +34,7 @@ func TestCommandSave(t *testing.T) {
 		// Expected output to compare
 		expectedOutput := `Pulling image: docker.io/alpine/curl:8.9.1
  archive alpine/curl:8.9.1.tgz already exist
-Tarball created successfully: images.tgz`
+Tarball created successfully: images-test.tgz`
 
 		assert.Equal(t, expectedOutput, output)
 
@@ -53,7 +53,7 @@ Tarball created successfully: images.tgz`
 	t.Run("test-chart4", func(t *testing.T) {
 
 		filePath := "image-test.tgz"
-		output, err := executeCommand(rootCmd, "save ../testdata/test-chart4 --dry-run=false --output "+filePath)
+		output, err := executeCommand(rootCmd, "save ../testdata/test-chart4 --dry-run=false -a datarobot.com/images --output "+filePath)
 		assert.NoError(t, err)
 
 		// Expected output to compare

--- a/testdata/test-chart5/Chart.yaml
+++ b/testdata/test-chart5/Chart.yaml
@@ -24,6 +24,12 @@ version: 0.1.0
 appVersion: "1.36.1"
 
 annotations:
+  custom/images-duplicated: |
+    - name: duplicated
+      image: docker.io/alpine/curl:8.9.1
+    - name: duplicated
+      image: docker.io/alpine/curl:8.9.1
+
   custom/images-extra: |
     - name: test-image3
       image: docker.io/alpine/curl:8.9.1


### PR DESCRIPTION
### Description of the change

skip duplicated image on save to prevent the following error

```
helm datarobot save testdata/test-chart5 -a custom/images-duplicated
Pulling image: docker.io/alpine/curl:8.9.1
Pulling image: docker.io/alpine/curl:8.9.1
Error: Error: failed to open tgz file "alpine/curl:8.9.1.tgz": open alpine/curl:8.9.1.tgz: no such file or directory
```

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

