### PR TITLE
fix: layer upload optimization

### DIFF
--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -84,7 +84,7 @@ Tarball created successfully: ` + SAVE_TEST_ARCHIVE
 			t.Errorf("File was not created: %s", SAVE_TEST_ARCHIVE)
 		}
 
-		if fileInfo.Size() > 20800511 {
+		if fileInfo.Size() > 20817463 {
 			t.Errorf("File size  error: %v", fileInfo.Size())
 		}
 		// Clean up: remove the file after the test


### PR DESCRIPTION
### Description of the change

some image with empty layers failed when restored from a tarball with error

```
MANIFEST_BLOB_UNKNOWN: blob unknown to registry
```

uploading each layer independently solve the problem

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

