### PR TITLE
[-] add retry count

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -126,7 +126,7 @@ type loadConfig struct {
 	SkipTlsVerify bool     `env:"SKIP_TLS_VERIFY"`
 	Overwrite     bool     `env:"OVERWRITE"`
 	DryRun        bool     `env:"DRY_RUN"`
-	RetryAttempts int      `env:"RETRY_ATTEMPTS,default=2"` // number of retries for pushing images
+	RetryAttempts int      `env:"RETRY_ATTEMPTS,default=1"` // number of retries for pushing images
 	RetryDelay    int      `env:"RETRY_DELAY,default=5"`    // in seconds, delay between retries
 }
 
@@ -149,7 +149,7 @@ func init() {
 	loadCmd.Flags().BoolVarP(&loadCfg.Overwrite, "overwrite", "", false, "Overwrite existing images")
 	loadCmd.Flags().BoolVarP(&loadCfg.DryRun, "dry-run", "", false, "Perform a dry run without making changes")
 	loadCmd.Flags().StringArrayVarP(&loadCfg.ImageSkip, "skip-image", "", []string{}, "Specify which image should be skipped (can be used multiple times)")
-	loadCmd.Flags().IntVarP(&loadCfg.RetryAttempts, "retry-attempts", "", 2, "Number of retries for pushing images")
+	loadCmd.Flags().IntVarP(&loadCfg.RetryAttempts, "retry-attempts", "", 1, "Number of retries for pushing images")
 	loadCmd.Flags().IntVarP(&loadCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
 }
 
@@ -356,7 +356,7 @@ func rebuildAndPushImage(manifest ImageManifest, c loadConfig, cmd *cobra.Comman
 		}
 	}
 
-	for i := range c.RetryAttempts {
+	for i := range c.RetryAttempts + 1 {
 		err = crane.Push(image, iUri.String(), crane.WithTransport(transport), crane.WithAuth(auth))
 		if err == nil {
 			return iUri.String(), nil // Successfully pushed the image

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/datarobot-oss/helm-datarobot-plugin/pkg/image_uri"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -125,6 +126,8 @@ type loadConfig struct {
 	SkipTlsVerify bool     `env:"SKIP_TLS_VERIFY"`
 	Overwrite     bool     `env:"OVERWRITE"`
 	DryRun        bool     `env:"DRY_RUN"`
+	RetryCount    int      `env:"RETRY_COUNT,default=1"` // number of retries for pushing images
+	RetryDelay    int      `env:"RETRY_DELAY,default=5"` // in seconds, delay between retries
 }
 
 var loadCfg loadConfig
@@ -146,6 +149,8 @@ func init() {
 	loadCmd.Flags().BoolVarP(&loadCfg.Overwrite, "overwrite", "", false, "Overwrite existing images")
 	loadCmd.Flags().BoolVarP(&loadCfg.DryRun, "dry-run", "", false, "Perform a dry run without making changes")
 	loadCmd.Flags().StringArrayVarP(&loadCfg.ImageSkip, "skip-image", "", []string{}, "Specify which image should be skipped (can be used multiple times)")
+	loadCmd.Flags().IntVarP(&loadCfg.RetryCount, "retry-count", "", 1, "Number of retries for pushing images")
+	loadCmd.Flags().IntVarP(&loadCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
 }
 
 func extractTarball(tarballPath, outputDir string) error {
@@ -351,13 +356,15 @@ func rebuildAndPushImage(manifest ImageManifest, c loadConfig, cmd *cobra.Comman
 		}
 	}
 
-	// Push the final image manifest
-	err = crane.Push(image, iUri.String(), crane.WithTransport(transport), crane.WithAuth(auth))
-	if err != nil {
-		return "", fmt.Errorf("error pushing image: %v", err)
-	} else {
-		return iUri.String(), nil
+	for i := range syncCfg.RetryCount {
+		err = crane.Push(image, iUri.String(), crane.WithTransport(transport), crane.WithAuth(auth))
+		if err == nil {
+			return iUri.String(), nil // Successfully pushed the image
+		}
+		cmd.Printf("Failed to push image: %s. Attempt %d/%d. Error: %v", image, i+1, c.RetryCount, err)
+		time.Sleep(time.Duration(c.RetryDelay) * time.Second) // Wait before retrying
 	}
+	return "", fmt.Errorf("error pushing image: %v", err)
 }
 
 func loadConfigFile(configPath string) (*v1.ConfigFile, error) {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -141,7 +141,7 @@ $ helm datarobot sync tests/charts/test-chart1/
 
 			cmd.Printf("Pushing image: %s\n\n", dstImage)
 			pushStatus := false
-			for i := range syncCfg.RetryAttempts {
+			for i := range syncCfg.RetryAttempts + 1 {
 				err = crane.Push(img, dstImage, crane.WithTransport(transport), crane.WithAuth(auth))
 				if err == nil {
 					pushStatus = true
@@ -175,7 +175,7 @@ type syncConfig struct {
 	ImageSkip      []string `env:"IMAGE_SKIP"`
 	Overwrite      bool     `env:"OVERWRITE"`
 	DryRun         bool     `env:"DRY_RUN"`
-	RetryAttempts  int      `env:"RETRY_ATTEMPTS,default=2"` // number of retries for pushing images
+	RetryAttempts  int      `env:"RETRY_ATTEMPTS,default=1"` // number of retries for pushing images
 	RetryDelay     int      `env:"RETRY_DELAY,default=5"`    // in seconds, delay between retries
 }
 
@@ -199,6 +199,6 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncCfg.Overwrite, "overwrite", "", false, "Overwrite existing images")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkip, "skip-image", "", []string{}, "Specify which image should be skipped (can be used multiple times)")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkipGroup, "skip-group", "", []string{}, "Specify which image group should be skipped (can be used multiple times)")
-	syncCmd.Flags().IntVarP(&syncCfg.RetryAttempts, "retry-attempts", "", 2, "Number of retries for pushing images")
+	syncCmd.Flags().IntVarP(&syncCfg.RetryAttempts, "retry-attempts", "", 1, "Number of retries for pushing images")
 	syncCmd.Flags().IntVarP(&syncCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/datarobot-oss/helm-datarobot-plugin/pkg/chartutil"
 	"github.com/datarobot-oss/helm-datarobot-plugin/pkg/image_uri"
@@ -139,10 +140,19 @@ $ helm datarobot sync tests/charts/test-chart1/
 			}
 
 			cmd.Printf("Pushing image: %s\n\n", dstImage)
-			if err := crane.Push(img, dstImage, crane.WithTransport(transport), crane.WithAuth(auth)); err != nil {
+			pushStatus := false
+			for i := range syncCfg.RetryCount {
+				err = crane.Push(img, dstImage, crane.WithTransport(transport), crane.WithAuth(auth))
+				if err == nil {
+					pushStatus = true
+					break
+				}
+				cmd.Printf("Failed to push image: %s. Attempt %d/%d. Error: %v", image, i+1, syncCfg.RetryCount, err)
+				time.Sleep(time.Duration(syncCfg.RetryDelay) * time.Second) // Wait before retrying
+			}
+			if !pushStatus {
 				return fmt.Errorf("failed to push image with authentication: %w", err)
 			}
-
 		}
 		return nil
 	},
@@ -165,6 +175,8 @@ type syncConfig struct {
 	ImageSkip      []string `env:"IMAGE_SKIP"`
 	Overwrite      bool     `env:"OVERWRITE"`
 	DryRun         bool     `env:"DRY_RUN"`
+	RetryCount     int      `env:"RETRY_COUNT,default=1"` // number of retries for pushing images
+	RetryDelay     int      `env:"RETRY_DELAY,default=5"` // in seconds, delay between retries
 }
 
 var syncCfg syncConfig
@@ -187,4 +199,6 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncCfg.Overwrite, "overwrite", "", false, "Overwrite existing images")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkip, "skip-image", "", []string{}, "Specify which image should be skipped (can be used multiple times)")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkipGroup, "skip-group", "", []string{}, "Specify which image group should be skipped (can be used multiple times)")
+	syncCmd.Flags().IntVarP(&syncCfg.RetryCount, "retry-count", "", 1, "Number of retries for pushing images")
+	syncCmd.Flags().IntVarP(&syncCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -141,13 +141,13 @@ $ helm datarobot sync tests/charts/test-chart1/
 
 			cmd.Printf("Pushing image: %s\n\n", dstImage)
 			pushStatus := false
-			for i := range syncCfg.RetryCount {
+			for i := range syncCfg.RetryAttempts {
 				err = crane.Push(img, dstImage, crane.WithTransport(transport), crane.WithAuth(auth))
 				if err == nil {
 					pushStatus = true
 					break
 				}
-				cmd.Printf("Failed to push image: %s. Attempt %d/%d. Error: %v", image, i+1, syncCfg.RetryCount, err)
+				cmd.Printf("Failed to push image: %s. Attempt %d/%d. Error: %v", image, i+1, syncCfg.RetryAttempts, err)
 				time.Sleep(time.Duration(syncCfg.RetryDelay) * time.Second) // Wait before retrying
 			}
 			if !pushStatus {
@@ -175,8 +175,8 @@ type syncConfig struct {
 	ImageSkip      []string `env:"IMAGE_SKIP"`
 	Overwrite      bool     `env:"OVERWRITE"`
 	DryRun         bool     `env:"DRY_RUN"`
-	RetryCount     int      `env:"RETRY_COUNT,default=1"` // number of retries for pushing images
-	RetryDelay     int      `env:"RETRY_DELAY,default=5"` // in seconds, delay between retries
+	RetryAttempts  int      `env:"RETRY_ATTEMPTS,default=2"` // number of retries for pushing images
+	RetryDelay     int      `env:"RETRY_DELAY,default=5"`    // in seconds, delay between retries
 }
 
 var syncCfg syncConfig
@@ -199,6 +199,6 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncCfg.Overwrite, "overwrite", "", false, "Overwrite existing images")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkip, "skip-image", "", []string{}, "Specify which image should be skipped (can be used multiple times)")
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkipGroup, "skip-group", "", []string{}, "Specify which image group should be skipped (can be used multiple times)")
-	syncCmd.Flags().IntVarP(&syncCfg.RetryCount, "retry-count", "", 1, "Number of retries for pushing images")
+	syncCmd.Flags().IntVarP(&syncCfg.RetryAttempts, "retry-attempts", "", 2, "Number of retries for pushing images")
 	syncCmd.Flags().IntVarP(&syncCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
 }

--- a/docs/helm-datarobot_load.md
+++ b/docs/helm-datarobot_load.md
@@ -45,7 +45,7 @@ helm-datarobot load [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
-      --retry-attempts int       Number of retries for pushing images (default 2)
+      --retry-attempts int       Number of retries for pushing images (default 1)
       --retry-delay int          Delay between retries in seconds (default 5)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)
       --suffix string            append suffix on repo name

--- a/docs/helm-datarobot_load.md
+++ b/docs/helm-datarobot_load.md
@@ -45,6 +45,8 @@ helm-datarobot load [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
+      --retry-count int          Number of retries for pushing images (default 1)
+      --retry-delay int          Delay between retries in seconds (default 5)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)
       --suffix string            append suffix on repo name
   -t, --token string             pass to auth

--- a/docs/helm-datarobot_load.md
+++ b/docs/helm-datarobot_load.md
@@ -45,7 +45,7 @@ helm-datarobot load [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
-      --retry-count int          Number of retries for pushing images (default 1)
+      --retry-attempts int       Number of retries for pushing images (default 2)
       --retry-delay int          Delay between retries in seconds (default 5)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)
       --suffix string            append suffix on repo name

--- a/docs/helm-datarobot_sync.md
+++ b/docs/helm-datarobot_sync.md
@@ -45,7 +45,7 @@ helm-datarobot sync [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
-      --retry-attempts int       Number of retries for pushing images (default 2)
+      --retry-attempts int       Number of retries for pushing images (default 1)
       --retry-delay int          Delay between retries in seconds (default 5)
       --skip-group stringArray   Specify which image group should be skipped (can be used multiple times)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)

--- a/docs/helm-datarobot_sync.md
+++ b/docs/helm-datarobot_sync.md
@@ -45,6 +45,8 @@ helm-datarobot sync [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
+      --retry-count int          Number of retries for pushing images (default 1)
+      --retry-delay int          Delay between retries in seconds (default 5)
       --skip-group stringArray   Specify which image group should be skipped (can be used multiple times)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)
       --suffix string            append suffix on repo name

--- a/docs/helm-datarobot_sync.md
+++ b/docs/helm-datarobot_sync.md
@@ -45,7 +45,7 @@ helm-datarobot sync [flags]
       --prefix string            append prefix on repo name
   -r, --registry string          registry to auth
       --repo string              rewrite the target repository name
-      --retry-count int          Number of retries for pushing images (default 1)
+      --retry-attempts int       Number of retries for pushing images (default 2)
       --retry-delay int          Delay between retries in seconds (default 5)
       --skip-group stringArray   Specify which image group should be skipped (can be used multiple times)
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)


### PR DESCRIPTION
### Description of the change

adding retry count in case of network problem or error from the registry

### Benefits

- easy retry on a single image failure 
- smooth sync and load process

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

