### PR TITLE
[FLEET-4956] Add new flags --upgrade-from and--no-upgrade for images|sync|list

### DIFF
--- a/cmd/images.go
+++ b/cmd/images.go
@@ -55,7 +55,7 @@ image: docker.io/datarobotdev/test-image3:3.0.0
 		if upgradeFrom != "" {
 			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
 			for _, img := range allImages {
-				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+				if img.UpgradeVersion == "" || IsUpgradeVersionSupported(img.UpgradeVersion, upgradeFrom) {
 					filteredImages = append(filteredImages, img)
 				}
 			}

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -51,6 +51,27 @@ image: docker.io/datarobotdev/test-image3:3.0.0
 		if err != nil {
 			return fmt.Errorf("Error ExtractImagesFromCharts: %v", err)
 		}
+
+		if upgradeFrom != "" {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range allImages {
+				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			allImages = filteredImages
+		}
+
+		if noUpgrade {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range allImages {
+				if img.Group != "upgrade" {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			allImages = filteredImages
+		}
+
 		yamlData, err := yaml.Marshal(&allImages)
 		if err != nil {
 			return fmt.Errorf("Error writing yaml: %v", err)
@@ -65,4 +86,6 @@ image: docker.io/datarobotdev/test-image3:3.0.0
 func init() {
 	rootCmd.AddCommand(imageCmd)
 	imageCmd.Flags().StringVarP(&annotation, "annotation", "a", "datarobot.com/images", "annotation to lookup")
+	imageCmd.Flags().StringVar(&upgradeFrom, "upgrade-from", "", "version to upgrade from")
+	imageCmd.Flags().BoolVar(&noUpgrade, "no-upgrade", false, "skip all images with the upgrade notation")
 }

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -7,15 +7,36 @@ import (
 )
 
 func TestCommandImages(t *testing.T) {
-	output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart1")
-	assert.NoError(t, err)
-	expectedOutput := `- name: test-image1
+	t.Run("base", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart1")
+		assert.NoError(t, err)
+		expectedOutput := `- name: test-image1
   image: docker.io/datarobotdev/test-image1:1.0.0
 - name: test-image2
   image: docker.io/datarobotdev/test-image2:2.0.0
 - name: test-image3
   image: docker.io/datarobotdev/test-image3:3.0.0`
 
-	// Compare the actual output with the expected output
-	assert.Equal(t, expectedOutput, output)
+		// Compare the actual output with the expected output
+		assert.Equal(t, expectedOutput, output)
+	})
+
+	t.Run("upgrade-from-match", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart7 -a datarobot.com/images --upgrade-from 10.0")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("upgrade-from-nomatch", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart7 -a datarobot.com/images --upgrade-from 11.0")
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("no-upgrade", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart7 -a datarobot.com/images --no-upgrade")
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
 }

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -36,7 +36,7 @@ func TestCommandImages(t *testing.T) {
 	t.Run("no-upgrade", func(t *testing.T) {
 		output, err := executeCommand(rootCmd, "image ../tests/charts/test-chart7 -a datarobot.com/images --no-upgrade")
 		assert.NoError(t, err)
-		assert.NotContains(t, output, "Pulling image: docker.io/alpine/curl:8.10.0")
+		assert.NotContains(t, output, "docker.io/alpine/curl:8.10.0")
 	})
 
 }

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -46,7 +46,7 @@ Tarball created successfully: image-load.tar.zst`
 		os.Setenv("REGISTRY_USERNAME", "admin")
 		os.Setenv("REGISTRY_PASSWORD", "pass")
 
-		output, err := executeCommand(rootCmd, "load "+LOAD_TEST_ARCHIVE+" -r localhost:5000 --insecure")
+		output, err := executeCommand(rootCmd, "load "+LOAD_TEST_ARCHIVE+" -r localhost:5000 --insecure --overwrite")
 		assert.NoError(t, err)
 		expectedLoadOutput := `Successfully pushed image localhost:5000/alpine/curl:8.9.1
 Successfully pushed image localhost:5000/busybox:1.36.1`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,8 @@ import (
 )
 
 var annotation string
+var upgradeFrom string
+var noUpgrade bool
 
 var rootCmd = &cobra.Command{
 	Use:   "helm-datarobot",

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -68,7 +68,7 @@ $ du -h images.tar.zst
 		if upgradeFrom != "" {
 			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
 			for _, img := range images {
-				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+				if img.UpgradeVersion == "" || IsUpgradeVersionSupported(img.UpgradeVersion, upgradeFrom) {
 					filteredImages = append(filteredImages, img)
 				}
 			}

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -65,6 +65,26 @@ $ du -h images.tar.zst
 			return fmt.Errorf("Error ExtractImagesFromCharts: %v", err)
 		}
 
+		if upgradeFrom != "" {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range images {
+				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			images = filteredImages
+		}
+
+		if noUpgrade {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range images {
+				if img.Group != "upgrade" {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			images = filteredImages
+		}
+
 		manifestFile := filepath.Join(saveCfg.OutputDir, "manifest.json")
 
 		// Step 1: Export Layers and Save Configurations
@@ -114,6 +134,8 @@ func init() {
 	saveCmd.Flags().StringVarP(&saveCfg.CompressionLevel, "level", "l", "best", "zstd compression level (Available options: fastest, default, better, best)")
 	saveCmd.Flags().StringArrayVarP(&saveCfg.ImageSkipGroup, "skip-group", "", []string{}, "Specify which image group should be skipped (can be used multiple times)")
 	saveCmd.Flags().BoolVarP(&saveCfg.DryRun, "dry-run", "", false, "Perform a dry run without making changes")
+	saveCmd.Flags().StringVar(&upgradeFrom, "upgrade-from", "", "version to upgrade from")
+	saveCmd.Flags().BoolVar(&noUpgrade, "no-upgrade", false, "Skip all images with the upgrade notation")
 }
 
 func exportLayersAndConfigs(images []chartutil.DatarobotImageDeclaration, c saveConfig, cmd *cobra.Command) (map[string]string, []ImageManifest) {

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -105,6 +105,24 @@ Skipping image: docker.io/alpine/curl:8.9.2
 		assert.Equal(t, expectedOutput, output)
 	})
 
+	t.Run("upgrade-from-match", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "save ../tests/charts/test-chart7 -a datarobot.com/images --upgrade-from 10.0  --dry-run --output "+SAVE_TEST_ARCHIVE)
+		assert.NoError(t, err)
+		assert.Contains(t, output, "Dry-Run] Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("upgrade-from-nomatch", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "save ../tests/charts/test-chart7 -a datarobot.com/images --upgrade-from 11.0  --dry-run --output "+SAVE_TEST_ARCHIVE)
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "Dry-Run] Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("no-upgrade", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "save ../tests/charts/test-chart7 -a datarobot.com/images --no-upgrade  --dry-run --output "+SAVE_TEST_ARCHIVE)
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "Dry-Run] Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
 	t.Run("wrong-level", func(t *testing.T) {
 		output, err := executeCommand(rootCmd, "save ../tests/charts/test-chart4 --level=wrong")
 		assert.Error(t, err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -58,7 +58,7 @@ $ helm datarobot sync tests/charts/test-chart1/
 		if upgradeFrom != "" {
 			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
 			for _, img := range images {
-				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+				if img.UpgradeVersion == "" || IsUpgradeVersionSupported(img.UpgradeVersion, upgradeFrom) {
 					filteredImages = append(filteredImages, img)
 				}
 			}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -55,6 +55,26 @@ $ helm datarobot sync tests/charts/test-chart1/
 			return fmt.Errorf("Error ExtractImagesFromCharts: %v", err)
 		}
 
+		if upgradeFrom != "" {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range images {
+				if img.UpgradeVersion == "" || strings.Contains(img.UpgradeVersion, upgradeFrom) {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			images = filteredImages
+		}
+
+		if noUpgrade {
+			filteredImages := make([]chartutil.DatarobotImageDeclaration, 0)
+			for _, img := range images {
+				if img.Group != "upgrade" {
+					filteredImages = append(filteredImages, img)
+				}
+			}
+			images = filteredImages
+		}
+
 		for _, image := range images {
 			iUri, err := image_uri.NewDockerUri(image.Image)
 			if err != nil {
@@ -201,4 +221,6 @@ func init() {
 	syncCmd.Flags().StringArrayVarP(&syncCfg.ImageSkipGroup, "skip-group", "", []string{}, "Specify which image group should be skipped (can be used multiple times)")
 	syncCmd.Flags().IntVarP(&syncCfg.RetryAttempts, "retry-attempts", "", 1, "Number of retries for pushing images")
 	syncCmd.Flags().IntVarP(&syncCfg.RetryDelay, "retry-delay", "", 5, "Delay between retries in seconds")
+	syncCmd.Flags().StringVar(&upgradeFrom, "upgrade-from", "", "version to upgrade from")
+	syncCmd.Flags().BoolVar(&noUpgrade, "no-upgrade", false, "Skip all images with the upgrade notation")
 }

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -117,12 +117,30 @@ Skipping image: docker.io/alpine/curl:8.9.2
 		assert.Equal(t, expectedOutput, output)
 	})
 
+	t.Run("upgrade-from-match", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../tests/charts/test-chart7 -r registry.example.com --dry-run -a datarobot.com/images --upgrade-from 10.0")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("upgrade-from-nomatch", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../tests/charts/test-chart7 -r registry.example.com --dry-run -a datarobot.com/images --upgrade-from 11.0")
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
+	t.Run("no-upgrade", func(t *testing.T) {
+		output, err := executeCommand(rootCmd, "sync ../tests/charts/test-chart7 -r registry.example.com --dry-run -a datarobot.com/images --no-upgrade")
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "Pulling image: docker.io/alpine/curl:8.10.0")
+	})
+
 	t.Run("local-registry-insecure", func(t *testing.T) {
 		os.Setenv("REGISTRY_USERNAME", "admin")
 		os.Setenv("REGISTRY_PASSWORD", "pass")
 		os.Setenv("REGISTRY_HOST", "localhost:5000")
 		os.Setenv("SKIP_TLS_VERIFY", "true")
-		output, err := executeCommand(rootCmd, "sync ../tests/charts/test-chart6 -a ex4")
+		output, err := executeCommand(rootCmd, "sync ../tests/charts/test-chart6 -a ex4 --overwrite")
 		assert.NoError(t, err)
 		expectedLoadOutput := `Pulling image: docker.io/alpine/curl:8.11.1
 Pushing image: localhost:5000/alpine/curl:8.11.1`

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -106,6 +106,19 @@ func SliceHas(slice []string, str string) bool {
 	return false
 }
 
+// IsUpgradeVersionSupported checks if targetVersion is exactly in the comma-separated versions list.
+func IsUpgradeVersionSupported(versions, targetVersion string) bool {
+	if versions == "" {
+		return true
+	}
+	for _, v := range strings.Split(versions, ",") {
+		if strings.TrimSpace(v) == targetVersion {
+			return true
+		}
+	}
+	return false
+}
+
 func ExtractImagesFromManifest(manifest string) ([]string, error) {
 	var manifestImages []string
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -94,3 +94,24 @@ E4bmYvhnmO/hlPwDN02OSWHYm6m0yIzWXw==
 		t.Fatal("Expected InsecureSkipVerify to be true")
 	}
 }
+
+func TestIsUpgradeVersionSupported(t *testing.T) {
+	tests := []struct {
+		versions      string
+		targetVersion string
+		expected      bool
+	}{
+		{"9.0,9.1,9.2,10.0", "0.0", false},
+		{"9.0,9.1,9.2,10.0", "9", false},
+		{"9.0,9.1,9.2,10.0", "9.0", true},
+		{"", "any", true},
+		{"9.0,9.1", "9.1", true},
+	}
+
+	for _, tt := range tests {
+		result := IsUpgradeVersionSupported(tt.versions, tt.targetVersion)
+		if result != tt.expected {
+			t.Errorf("IsUpgradeVersionSupported(%q, %q) = %v; want %v", tt.versions, tt.targetVersion, result, tt.expected)
+		}
+	}
+}

--- a/docs/helm-datarobot_images.md
+++ b/docs/helm-datarobot_images.md
@@ -44,8 +44,10 @@ helm-datarobot images [flags]
 ### Options
 
 ```
-  -a, --annotation string   annotation to lookup (default "datarobot.com/images")
-  -h, --help                help for images
+  -a, --annotation string     annotation to lookup (default "datarobot.com/images")
+  -h, --help                  help for images
+      --no-upgrade            skip all images with the upgrade notation
+      --upgrade-from string   version to upgrade from
 ```
 
 ### SEE ALSO

--- a/docs/helm-datarobot_save.md
+++ b/docs/helm-datarobot_save.md
@@ -32,9 +32,11 @@ helm-datarobot save [flags]
       --dry-run                  Perform a dry run without making changes
   -h, --help                     help for save
   -l, --level string             zstd compression level (Available options: fastest, default, better, best) (default "best")
+      --no-upgrade               Skip all images with the upgrade notation
   -o, --output string            file to save (default "images.tar.zst")
       --output-dir string        file to save (default "export")
       --skip-group stringArray   Specify which image group should be skipped (can be used multiple times)
+      --upgrade-from string      version to upgrade from
 ```
 
 ### SEE ALSO

--- a/docs/helm-datarobot_sync.md
+++ b/docs/helm-datarobot_sync.md
@@ -40,6 +40,7 @@ helm-datarobot sync [flags]
   -h, --help                     help for sync
   -i, --insecure                 Skip server certificate verification
   -K, --key string               Path to the client key
+      --no-upgrade               Skip all images with the upgrade notation
       --overwrite                Overwrite existing images
   -p, --password string          pass to auth
       --prefix string            append prefix on repo name
@@ -51,6 +52,7 @@ helm-datarobot sync [flags]
       --skip-image stringArray   Specify which image should be skipped (can be used multiple times)
       --suffix string            append suffix on repo name
   -t, --token string             pass to auth
+      --upgrade-from string      version to upgrade from
   -u, --username string          username to auth
 ```
 

--- a/pkg/chartutil/datarobot_images.go
+++ b/pkg/chartutil/datarobot_images.go
@@ -13,10 +13,11 @@ import (
 )
 
 type DatarobotImageDeclaration struct {
-	Name  string `yaml:"name"`
-	Image string `yaml:"image"`
-	Tag   string `yaml:"tag,omitempty"`
-	Group string `yaml:"group,omitempty"`
+	Name           string `yaml:"name"`
+	Image          string `yaml:"image"`
+	Tag            string `yaml:"tag,omitempty"`
+	Group          string `yaml:"group,omitempty"`
+	UpgradeVersion string `yaml:"upgrade_version,omitempty"`
 }
 
 type ChartImages struct {

--- a/pkg/chartutil/datarobot_images_test.go
+++ b/pkg/chartutil/datarobot_images_test.go
@@ -91,6 +91,17 @@ func TestExtractImagesFromCharts(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name:       "test-chart5 with datarobot.com/images",
+			chartPaths: []string{"../../tests/charts/test-chart5"},
+			annotation: "datarobot.com/images",
+			expectedImages: []DatarobotImageDeclaration{
+				{Name: "test-image3", Image: "docker.io/alpine/curl:8.9.1", Tag: "stable"},
+				{Name: "test-image30", Image: "busybox:1.36.1", Tag: "simple"},
+				{Name: "test-image31", Image: "docker.io/alpine/curl:8.10.0", Tag: ""},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/charts/test-chart7/Chart.yaml
+++ b/tests/charts/test-chart7/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: test-chart1
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+annotations:
+  datarobot.com/images: |
+    - name: test-image
+      image: docker.io/datarobotdev/test-image1:{{.Chart.AppVersion}}
+    - name: test-image-upgrade
+      image: docker.io/alpine/curl:8.10.0
+      group: upgrade
+      upgrade_version: 9.0,9.1,9.2,10.0

--- a/tests/charts/test-chart7/templates/NOTES.txt
+++ b/tests/charts/test-chart7/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "test-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "test-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "test-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "test-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/tests/charts/test-chart7/templates/_helpers.tpl
+++ b/tests/charts/test-chart7/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "test-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "test-chart.labels" -}}
+helm.sh/chart: {{ include "test-chart.chart" . }}
+{{ include "test-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "test-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "test-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "test-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tests/charts/test-chart7/templates/deployment.yaml
+++ b/tests/charts/test-chart7/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "test-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "test-chart.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "test-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tests/charts/test-chart7/templates/hpa.yaml
+++ b/tests/charts/test-chart7/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "test-chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tests/charts/test-chart7/templates/ingress.yaml
+++ b/tests/charts/test-chart7/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "test-chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/tests/charts/test-chart7/templates/service.yaml
+++ b/tests/charts/test-chart7/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "test-chart.selectorLabels" . | nindent 4 }}

--- a/tests/charts/test-chart7/templates/serviceaccount.yaml
+++ b/tests/charts/test-chart7/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "test-chart.serviceAccountName" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/tests/charts/test-chart7/templates/tests/test-connection.yaml
+++ b/tests/charts/test-chart7/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "test-chart.fullname" . }}-test-connection"
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "test-chart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/tests/charts/test-chart7/values.yaml
+++ b/tests/charts/test-chart7/values.yaml
@@ -1,0 +1,109 @@
+# Default values for test-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: docker.io/datarobotdev/test-image1
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+STASSTASSTAS: true

--- a/tests/charts/test-chart7/values.yaml
+++ b/tests/charts/test-chart7/values.yaml
@@ -105,5 +105,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-STASSTASSTAS: true


### PR DESCRIPTION
### Description of the change

Add new flags --upgrade-from and--no-upgrade for image|sync|list to skip certain images only useful during upgrades for `images`, `sync` and `save`.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

This enables generating smaller image manifests without old EOL images that are only needed during upgrades from old versions of DataRobot

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None

<!-- Describe any known limitations with your change -->

### Additional information

Covered with unit tests.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes which images are selected for `save`/`sync`/`images`, potentially omitting required images if chart annotations or version matching are misconfigured.
> 
> **Overview**
> Adds `--upgrade-from` and `--no-upgrade` flags to `images`, `save`, and `sync` to filter chart-declared images: `--upgrade-from` includes only upgrade images whose `upgrade_version` list contains the specified source version, and `--no-upgrade` drops any image in the `upgrade` group.
> 
> Extends `DatarobotImageDeclaration` with an optional `upgrade_version` field, introduces `IsUpgradeVersionSupported()` for exact version matching, updates generated command docs, and adds a new `test-chart7` plus unit tests covering the new filtering behavior (and adjusts existing load/sync tests to pass `--overwrite`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e442715b6f2e69c036709788cd6df0cb6d3c6996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->